### PR TITLE
subprocess instead of xonsh !()

### DIFF
--- a/xontrib/direnv.xsh
+++ b/xontrib/direnv.xsh
@@ -1,10 +1,10 @@
-import json
+import json, subprocess
 
 def __direnv():
-    r = !(direnv export json)
-    r.end()
-    if len(r.output) > 0:
-        lines = json.loads(r.output)
+    p = subprocess.Popen('direnv export json'.split(), stdout=subprocess.PIPE)
+    r, _ = p.communicate()
+    if len(r) > 0:
+        lines = json.loads(r)
         for k,v in lines.items():
             if v is None:
                 del(__xonsh__.env[k])


### PR DESCRIPTION
Fixes https://github.com/74th/xonsh-direnv/issues/2

Seems to be more robust to use pure Python, since xonsh has a history of breaking its built-ins.