### PR TITLE
Remove subprocess usage, remove spurious direnv calls

### DIFF
--- a/xontrib/direnv.xsh
+++ b/xontrib/direnv.xsh
@@ -4,14 +4,8 @@ import json, subprocess
 $UPDATE_OS_ENVIRON = True
 
 def __direnv():
-    p = subprocess.Popen(
-        'direnv export json'.split(),
-        stdout=subprocess.PIPE,
-        env=__xonsh__.env.detype()
-    )
-    r, _ = p.communicate()
-    p.wait()
-    if r and p.returncode == 0:
+    r = $(direnv export json)
+    if r:
         lines = json.loads(r)
         for k, v in lines.items():
             if v is None:
@@ -25,11 +19,13 @@ def __direnv_post_rc() -> None:
 
 @events.on_chdir
 def __direnv_chdir(olddir: str, newdir: str) -> None:
-    __direnv()
-
-@events.on_precommand
-def __direnv_precommand(cmd: str) -> None:
-    __direnv()
+    if ${...}.get("DIRENV_DIR") is not None:
+        direnv_dir = pf"{$DIRENV_DIR.strip('-')}"
+        new = pf"{newdir}".absolute()
+        if not set(direnv_dir.parts).issubset(new.parts):
+            __direnv()
+    else:
+        __direnv()
 
 @events.on_postcommand
 def __direnv_postcommand(cmd: str, rtn: int, out: str or None, ts: list) -> None:


### PR DESCRIPTION
This removes the usage of `subprocess` directly in favor of using `xonsh` to make the initial `direnv` call.

It also removes the `precommand` hook, since the combination of `chdir` and `postcommand` should cover just about everything (especially changes to `watch`ed files).

Finally, the `chdir` event only fires when we change into a new `direnv` dir, and not every time we move down the directory tree, so we aren't constantly reloading the same `envrc` (which can get quite slow when using `nix`)