### PR TITLE
Use python code for the formatted string

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,3 +57,4 @@ Contributors
 * Greg Hellings (@greg-hellings, contributor)
 * Andy Kipp (@anki-code, contributor)
 * Alexander Sosedkin (@t184256, contributor)
+* Mark Bestley (@bestlem, contributor)

--- a/xontrib/direnv.xsh
+++ b/xontrib/direnv.xsh
@@ -20,7 +20,7 @@ def __direnv_post_rc(**kwargs) -> None:
 @events.on_chdir
 def __direnv_chdir(olddir: str, newdir: str, **kwargs) -> None:
     if ${...}.get("DIRENV_DIR") is not None:
-        direnv_dir = pf"{$DIRENV_DIR.strip('-')}"
+        direnv_dir = pf"{__xonsh__.env.get('DIRENV_DIR').strip('-')}"
         new = pf"{newdir}".absolute()
         if not set(direnv_dir.parts).issubset(new.parts):
             __direnv()


### PR DESCRIPTION
Allow direnv to work under python 3.12.

Fixes https://github.com/74th/xonsh-direnv/issues/16

Uses pure python to get the environment variable rather than using xonsh syntax.